### PR TITLE
feat: Merge plugin factory's settings with default, allow partial overrides of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,40 @@ import someImage from "./some-image.png"; // <-- With the above config, this sho
   - `[hash]`: The has of the input file.
   - `[extname]`: The extension of the input file.
 - `publicPath` (default: `""`): A folder for where to put optimized assets. Use this to separate your images into a separate folder.
-- `gifsicle`: (default: `{ optimizationLevel: 3 }`): Settings to pass to [`imagemin-gifsicle`](https://www.npmjs.com/package/imagemin-gifsicle).
-- `jpegtran` (default: `{ progressive: true }`): Settings to pass to [`imagemin-jpegtran`](https://www.npmjs.com/package/imagemin-jpegtran).
-- `pngquant`: (default: `{ speed: 1, strip: true }`): Settings to pass to [`imagemin-pngquant`](https://www.npmjs.com/package/imagemin-pngquant).
-- `svgo`: (default: `{ precision: 1, multipass: true }`): Settings to pass to [`imagemin-svgo`](https://www.npmjs.com/package/imagemin-svgo).
-- `plugins`: Array of [plugins](https://www.npmjs.com/search?q=keywords:imageminplugin) to pass to `imagemin`. By default, `imagemin-gifsicle`, `imagemin-jpegtran`, `imagemin-pngquant`, and `imagemin-svgo` are used. Be aware that specifying this option will totally overwrite the array of default plugins, so you will need to specify optimizers for every file type! Most often, the defaults are just fine, so only modify this if you're quite comfortable with configuring `imagemin`.
+- `gifsicle`: (default: `{ optimizationLevel: 3 }`): Settings to merge with default, to pass to [`imagemin-gifsicle`](https://www.npmjs.com/package/imagemin-gifsicle).
+- `jpegtran` (default: `{ progressive: true }`): Settings to merge with default, to pass to [`imagemin-jpegtran`](https://www.npmjs.com/package/imagemin-jpegtran).
+- `pngquant`: (default: `{ speed: 1, strip: true }`): Settings to merge with default, to pass to [`imagemin-pngquant`](https://www.npmjs.com/package/imagemin-pngquant).
+- `svgo`: (default: `{ precision: 1, multipass: true }`): Settings to merge with default, to pass to [`imagemin-svgo`](https://www.npmjs.com/package/imagemin-svgo).
+- `plugins`: object with *plugin names* as keys and [plugins](https://www.npmjs.com/search?q=keywords:imageminplugin) as value to pass to `imagemin`. By default, `{gifsicle: 'imagemin-gifsicle', jpegtran: 'imagemin-jpegtran', pngquant: 'imagemin-pngquant', svgo: 'imagemin-svgo'}` are used. Each plugin
+function must be a factory, taking the plugin's config (the object at `options[pluginName]`, merged with defaults), and returning an imagemin buffer transformer.
+
+## Using custom plugins
+
+You can use custom plugins the following way:
+
+```javascript
+// rollup.config.js
+import imagemin from "rollup-plugin-imagemin";
+import myCustomPlugin from "imagemin-my-custom-plugin";
+
+export default {
+  plugins: [
+    imagemin({
+        myCustomPlugin: {
+            // Config to pass to `myCustomPlugin`'s factory
+        },
+        plugins: {
+            myCustomPlugin,
+        }
+    })
+  ],
+  input: "src/index.js"
+  output: {
+    format: "esm",
+    file: "./dist/index.js"
+  }
+};
+```
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-imagemin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4779,6 +4779,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-mock": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
+      "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm run clean && npx rollup -c rollup.config.js",
     "lint": "npx eslint src/index.mjs test/index.mjs",
     "test": "npx mocha --require @babel/register ./test/index.mjs",
+    "prepare": "npm run build",
     "prepublish": "npm run lint && npm test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mocha": "^6.0.2",
     "rimraf": "^2.6.3",
     "rollup": "^1.4.1",
-    "rollup-plugin-babel": "^4.3.2"
+    "rollup-plugin-babel": "^4.3.2",
+    "simple-mock": "^0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
     "webperf"
   ],
   "author": "Jeremy L. Wagner <jeremy.l.wagner@gmail.com>",
+  "contributors": [
+      {
+          "name": "GerkinDev",
+          "email": "agermain@ithoughts.io",
+          "url": "https://ithoughts.io/"
+      }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/malchata/rollup-plugin-imagemin/issues"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -63,21 +63,22 @@ export default function (userOptions = {}) {
   userOptions = dropUndefinedKeys(userOptions);
 
   // Inject default plugin factories
-  const allPluginsFactories = Object.assign({
+  const allPluginsFactories = {
     jpegtran: imageminJpegtran,
     pngquant: imageminPngquant,
     gifsicle: imageminGifsicle,
-    svgo: imageminSvgo
-  }, userOptions.plugins);
+    svgo: imageminSvgo,
+    ...(userOptions.plugins)
+  };
     // Get pairs to use array functions
   const allPluginsFactoriesPairs = Object.entries(allPluginsFactories);
   // Merge 1st level options
-  const pluginOptions = Object.assign({}, defaultOptions, userOptions);
+  const pluginOptions = {...defaultOptions, ...userOptions};
   // Merge user options with defaults for each plugin
   allPluginsFactoriesPairs.reduce((pluginOptionsAcc, [pluginName,]) => {
     // Remove `undefined` plugin user options
     const pluginUserOpts = dropUndefinedKeys(userOptions[pluginName] || {});
-    pluginOptionsAcc[pluginName] = Object.assign(defaultOptions[pluginName], pluginUserOpts);
+    pluginOptionsAcc[pluginName] = {...(defaultOptions[pluginName]), ...pluginUserOpts};
     return pluginOptionsAcc;
   }, pluginOptions);
   // Run factories

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -19,37 +19,70 @@ const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const mkpathAsync = util.promisify(mkpath);
 
+// Returns a new object each time, so that it can't be modified (while it is exported)
+// It is required to export this value for testing
+export const getDefaultOptions = () => JSON.parse(JSON.stringify({
+  disable: false,
+  verbose: false,
+  emitFiles: true,
+  hashLength: 16,
+  include: "**/*.{svg,png,jpg,jpeg,gif}",
+  exclude: "",
+  fileName: "[name]-[hash][extname]",
+  publicPath: "",
+  jpegtran: {
+    progressive: true
+  },
+  pngquant: {
+    speed: 1,
+    strip: true
+  },
+  gifsicle: {
+    optimizationLevel: 3
+  },
+  svgo: {
+    precision: 1,
+    multipass: true
+  },
+  plugins: {}
+}));
+
+const dropUndefinedKeys = obj => Object.entries(obj)
+  .reduce((acc, [key, val]) => {
+    if(typeof val !== "undefined"){
+      acc[key] = val;
+    }
+    return acc;
+  }, {});
+
 export default function (userOptions = {}) {
   // Default options
-  let defaultOptions = {
-    disable: false,
-    verbose: false,
-    emitFiles: true,
-    hashLength: 16,
-    include: "**/*.{svg,png,jpg,jpeg,gif}",
-    exclude: "",
-    fileName: "[name]-[hash][extname]",
-    publicPath: "",
-    jpegtran: {
-      progressive: true
-    },
-    pngquant: {
-      speed: 1,
-      strip: true
-    },
-    gifsicle: {
-      optimizationLevel: 3
-    },
-    svgo: {
-      precision: 1,
-      multipass: true
-    },
-    plugins: []
-  };
+  const defaultOptions = getDefaultOptions();
 
-  defaultOptions.plugins.push(imageminJpegtran(defaultOptions.jpegtran), imageminPngquant(defaultOptions.pngquant), imageminGifsicle(defaultOptions.gifsicle), imageminSvgo(defaultOptions.svgo));
+  // Remove `undefined` user options
+  userOptions = dropUndefinedKeys(userOptions);
 
-  const pluginOptions = Object.assign(defaultOptions, userOptions);
+  // Inject default plugin factories
+  const allPluginsFactories = Object.assign({
+    jpegtran: imageminJpegtran,
+    pngquant: imageminPngquant,
+    gifsicle: imageminGifsicle,
+    svgo: imageminSvgo
+  }, userOptions.plugins);
+    // Get pairs to use array functions
+  const allPluginsFactoriesPairs = Object.entries(allPluginsFactories);
+  // Merge 1st level options
+  const pluginOptions = Object.assign({}, defaultOptions, userOptions);
+  // Merge user options with defaults for each plugin
+  allPluginsFactoriesPairs.reduce((pluginOptionsAcc, [pluginName,]) => {
+    // Remove `undefined` plugin user options
+    const pluginUserOpts = dropUndefinedKeys(userOptions[pluginName] || {});
+    pluginOptionsAcc[pluginName] = Object.assign(defaultOptions[pluginName], pluginUserOpts);
+    return pluginOptionsAcc;
+  }, pluginOptions);
+  // Run factories
+  pluginOptions.plugins = allPluginsFactoriesPairs.map(([pluginName, factoryFunction]) => factoryFunction(pluginOptions[pluginName]));
+
   const filter = createFilter(pluginOptions.include, pluginOptions.exclude);
   const logPrefix = "imagemin:";
   let assets = {};

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -153,7 +153,7 @@ describe("rollup-plugin-imagemin", () => {
         it(`Should call ${pluginName} with custom option`, () =>
           mockPlugin(`fixtures/${type}.js`, `output/${type}.js`, pluginName, overrideSample).then(({ factoryMock, transformMock }) => {
             assert.equal(factoryMock.callCount, 1);
-            assert.deepEqual(factoryMock.lastCall.args, [Object.assign(getDefaultOptions()[pluginName], overrideSample)]);
+            assert.deepEqual(factoryMock.lastCall.args, [{...(getDefaultOptions()[pluginName]), ...overrideSample}]);
             assert.equal(transformMock.callCount, 1);
             assert.equal(transformMock.lastCall.args.length, 1);
             assert.ok(transformMock.lastCall.args[0] instanceof Buffer);
@@ -161,7 +161,7 @@ describe("rollup-plugin-imagemin", () => {
         it(`Should call ${pluginName} with custom options`, () =>
           mockPlugin(`fixtures/${type}.js`, `output/${type}.js`, pluginName, customOpt).then(({ factoryMock, transformMock }) => {
             assert.equal(factoryMock.callCount, 1);
-            assert.deepEqual(factoryMock.lastCall.args, [Object.assign(getDefaultOptions()[pluginName], customOpt)]);
+            assert.deepEqual(factoryMock.lastCall.args, [{...(getDefaultOptions()[pluginName]), ...customOpt}]);
             assert.equal(transformMock.callCount, 1);
             assert.equal(transformMock.lastCall.args.length, 1);
             assert.ok(transformMock.lastCall.args[0] instanceof Buffer);

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -7,8 +7,9 @@ import assert from "assert";
 import util from "util";
 
 // Test-specific
-import imagemin from "../src";
+import imagemin, { getDefaultOptions } from "../src";
 import rimraf from "rimraf";
+import { stub } from "simple-mock";
 import { rollup } from "rollup";
 
 // Change process to tests directory
@@ -131,6 +132,43 @@ describe("rollup-plugin-imagemin", () => {
       });
     });
   });
+
+  describe("Plugin options", () => {
+    const customOpt = {foo: "bar"};
+    [
+      {type: "gif", pluginName: "gifsicle", overrideSample: {precision: 42}},
+      {type: "jpg", pluginName: "jpegtran", overrideSample: {progressive: false}},
+      {type: "png", pluginName: "pngquant", overrideSample: {speed: 42}},
+      {type: "svg", pluginName: "svgo",     overrideSample: {precision: 42}},
+    ].forEach(({type, pluginName, overrideSample}) => {
+      describe(type.toUpperCase(), () => {
+        it(`Should call ${pluginName} with default option`, () =>
+          mockPlugin(`fixtures/${type}.js`, `output/${type}.js`, pluginName).then(({ factoryMock, transformMock }) => {
+            assert.equal(factoryMock.callCount, 1);
+            assert.deepEqual(factoryMock.lastCall.args, [getDefaultOptions()[pluginName]]);
+            assert.equal(transformMock.callCount, 1);
+            assert.equal(transformMock.lastCall.args.length, 1);
+            assert.ok(transformMock.lastCall.args[0] instanceof Buffer);
+          }));
+        it(`Should call ${pluginName} with custom option`, () =>
+          mockPlugin(`fixtures/${type}.js`, `output/${type}.js`, pluginName, overrideSample).then(({ factoryMock, transformMock }) => {
+            assert.equal(factoryMock.callCount, 1);
+            assert.deepEqual(factoryMock.lastCall.args, [Object.assign(getDefaultOptions()[pluginName], overrideSample)]);
+            assert.equal(transformMock.callCount, 1);
+            assert.equal(transformMock.lastCall.args.length, 1);
+            assert.ok(transformMock.lastCall.args[0] instanceof Buffer);
+          }));
+        it(`Should call ${pluginName} with custom options`, () =>
+          mockPlugin(`fixtures/${type}.js`, `output/${type}.js`, pluginName, customOpt).then(({ factoryMock, transformMock }) => {
+            assert.equal(factoryMock.callCount, 1);
+            assert.deepEqual(factoryMock.lastCall.args, [Object.assign(getDefaultOptions()[pluginName], customOpt)]);
+            assert.equal(transformMock.callCount, 1);
+            assert.equal(transformMock.lastCall.args.length, 1);
+            assert.ok(transformMock.lastCall.args[0] instanceof Buffer);
+          }));
+      });
+    });
+  });
 });
 
 function promise(fn, ...args) {
@@ -141,9 +179,33 @@ function promise(fn, ...args) {
   });
 }
 
-function run(input, file, disable = false, emitFiles = true) {
+function mockPlugin(inputFile, outputFile, pluginName, config){
+  // Simple pass-through mock
+  const transformMock = stub().callFn(buf => buf);
+  const factoryMock = stub().returnWith(transformMock);
   return rollup({
-    input,
+    input: inputFile,
+    plugins: [
+      imagemin({
+        fileName: "[name][extname]",
+        [pluginName]: config,
+        plugins: {
+          [pluginName]: factoryMock
+        },
+      })
+    ]
+  }).then(bundle => bundle.write({
+    format: "esm",
+    file: outputFile,
+    assetFileNames: "[name][extname]"
+  })).then(() => Promise.resolve({
+    factoryMock,
+    transformMock,
+  }));
+}
+function run(inputFile, outputFile, disable = false, emitFiles = true) {
+  return rollup({
+    input: inputFile,
     plugins: [
       imagemin({
         disable,
@@ -153,7 +215,7 @@ function run(input, file, disable = false, emitFiles = true) {
     ]
   }).then(bundle => bundle.write({
     format: "esm",
-    file,
+    file: outputFile,
     assetFileNames: "[name][extname]"
   }));
 }


### PR DESCRIPTION
Give to the user the ability to specify options to merge with default before passing them to plugin's factories.
Allow to merge custom plugins with default plugins
Add dynamic plugins configuration depending on the plugin's name

✔ Tests
✔ Docs
✔ Lint

I've read the *Contributing guidelines*, I'm aware I should have opened an issue about this feature, but I personnaly needed it, so I'm using my repository instead of your module. I just propose you to integrate it in your module if you'd like to.