### PR TITLE
Update @rollup/pluginutils to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -833,15 +833,36 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/pluginutils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
+      "integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+      "requires": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+          "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg=="
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
     "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
+      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
       "dev": true
     },
     "@types/events": {
@@ -2107,7 +2128,8 @@
     "estree-walker": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -4160,14 +4182,22 @@
       }
     },
     "rollup": {
-      "version": "1.16.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.16.7.tgz",
-      "integrity": "sha512-P3GVcbVSLLjHWFLKGerYRe3Q/yggRXmTZFx/4WZf4wzGwO6hAg5jyMAFMQKc0dts8rFID4BQngfoz6yQbI7iMQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "^12.0.10",
-        "acorn": "^6.1.1"
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-babel": {
@@ -4184,6 +4214,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
       "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "imagemin-optipng": "^7.0.0",
     "imagemin-svgo": "^7.0.0",
     "mkpath": "^1.0.0",
-    "rollup-pluginutils": "^2.8.1"
+    "@rollup/pluginutils": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",
@@ -54,7 +54,7 @@
     "eslint": "^6.0.1",
     "mocha": "^6.1.4",
     "rimraf": "^2.6.3",
-    "rollup": "^1.16.7",
+    "rollup": "^1.20.0",
     "rollup-plugin-babel": "^4.3.3",
     "simple-mock": "^0.8.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import util from "util";
 import crypto from "crypto";
 
 // Plugin-specific
-import { createFilter } from "rollup-pluginutils";
+import { createFilter } from "@rollup/pluginutils";
 import chalk from "chalk";
 import mkpath from "mkpath";
 import imagemin from "imagemin";


### PR DESCRIPTION
This improves the include/excludes and allows matching of files not in `process.cwd()`
This contains 3 breaking changes in `@ollup/pluginutils`:
* https://github.com/rollup/plugins/pull/517
* Minimum compatible Rollup version is 1.20.0
* Minimum supported Node version is 8.0.0

Since we only use filter, and it doesn't use much of node, or rollup I think only the first breaking change will have much of an effect on our users.