### PR TITLE
Fix incorrect outputFileName slash on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ export default function (userOptions = {}) {
             plugins: pluginOptions.plugins
           }).then(optimizedBuffer => {
             hash = crypto.createHash("sha1").update(optimizedBuffer).digest("hex").substr(0, pluginOptions.hashLength);
-            outputFileName = path.join(pluginOptions.publicPath, pluginOptions.fileName.replace(/\[name\]/i, name).replace(/\[hash\]/i, hash).replace(/\[extname\]/i, extname));
+            outputFileName = path.join(pluginOptions.publicPath, pluginOptions.fileName.replace(/\[name\]/i, name).replace(/\[hash\]/i, hash).replace(/\[extname\]/i, extname)).replace(/\\/g, "/");
             assets[outputFileName] = optimizedBuffer;
 
             if (pluginOptions.verbose) {
@@ -138,7 +138,7 @@ export default function (userOptions = {}) {
           });
         } else {
           hash = crypto.createHash("sha1").update(buffer).digest("hex").substr(0, pluginOptions.hashLength);
-          outputFileName = path.join(pluginOptions.publicPath, pluginOptions.fileName.replace(/\[name\]/i, name).replace(/\[hash\]/i, hash).replace(/\[extname\]/i, extname));
+          outputFileName = path.join(pluginOptions.publicPath, pluginOptions.fileName.replace(/\[name\]/i, name).replace(/\[hash\]/i, hash).replace(/\[extname\]/i, extname)).replace(/\\/g, "/");
           assets[outputFileName] = buffer;
 
           return `export default new URL("${outputFileName}", import.meta.url).href;`;


### PR DESCRIPTION
When building on Windows, there'll be an error in the browser when trying to import the generated module:
```
Uncaught TypeError: Failed to construct 'URL': Invalid URL
```

This is because `path.join` uses backslashes on Windows instead of forward ones that `new URL()` expects:
```js
// error
new URL('foo\bar', import.meta.url);

// all good
new URL('foo\bar'.replace(/\\/g, '/'), import.meta.url);
```