### PR TITLE
Normalise the path passed with load(id)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ export default function (userOptions = {}) {
       }
     },
     load (id) {
+      id = path.resolve(id); // Normalise id to match native representation. Required if used with Vite which uses Unix style paths for id.
       if (!filter(id)) {
         return null;
       }


### PR DESCRIPTION
Without this mod, the plugin will not work with Vite on Windows as Vite does not pass down a drive letter and the path has Unix style separators. As a result on Windows filter matching (`include`, `exclude` patterns) is broken and also the `preserveTree` configuration parameter won't match. Once the id is converted to the native representation, include/exclude filters work and also the `preserveTree` configuration can be set for example to `preserveTree: 'src'` which will nicley regenerate the relative path structure in a Vue/Vite project, so `src/assets/image.png` becomes `dist/assets/image.png`.