### PR TITLE
Removed unneeded part of `if` statement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ export function imagemin (userOptions = {}) {
   return {
     name: "imagemin",
     buildStart () {
-      if (pluginOptions.verbose && pluginOptions.disable) {
+      if (pluginOptions.verbose) {
         pluginOptions.disable ? console.log(chalk.yellow.bold(`${logPrefix} Skipping image optimizations.`)) : console.log(chalk.green.bold(`${logPrefix} Optimizing images...`));
       }
     },


### PR DESCRIPTION
The line inside the `if` block already checks this and acts on the _falsy_ case, so it shouldn't be in the `if`.